### PR TITLE
Binaries

### DIFF
--- a/src/Transport/Fs/Filesystem/Storage.php
+++ b/src/Transport/Fs/Filesystem/Storage.php
@@ -6,6 +6,7 @@ use Jackalope\Transport\Fs\NodeSerializer\YamlNodeSerializer;
 use Jackalope\Transport\Fs\Filesystem\PathRegistry;
 use Jackalope\Transport\Fs\Filesystem\Storage\NodeWriter;
 use Jackalope\Transport\Fs\Filesystem\Storage\StorageHelper;
+use Jackalope\Transport\Fs\Filesystem\Storage\NodeReader;
 
 class Storage
 {

--- a/src/Transport/Fs/Filesystem/Storage/NodeReader.php
+++ b/src/Transport/Fs/Filesystem/Storage/NodeReader.php
@@ -53,14 +53,14 @@ class NodeReader
         }
 
         // the user shouldn't know about the internal UUID
-        if (!isset($node->{self::INTERNAL_UUID})) {
-            throw new \RuntimeException(sprintf('Internal UUID propery (%s) not set on node at path "%s". This should not happen!', self::INTERNAL_UUID, $path));
+        if (!isset($node->{Storage::INTERNAL_UUID})) {
+            throw new \RuntimeException(sprintf('Internal UUID propery (%s) not set on node at path "%s". This should not happen!', Storage::INTERNAL_UUID, $path));
         }
 
-        $internalUuid = $node->{self::INTERNAL_UUID};
+        $internalUuid = $node->{Storage::INTERNAL_UUID};
 
         $this->pathRegistry->registerUuid($path, $internalUuid);
-        unset($node->{self::INTERNAL_UUID});
+        unset($node->{Storage::INTERNAL_UUID});
 
         return $node;
     }
@@ -70,8 +70,8 @@ class NodeReader
         $nodes = array();
 
         foreach ($uuids as $uuid) {
-            $indexName = $internal ? self::IDX_INTERNAL_UUID : self::IDX_JCR_UUID;
-            $path = self::INDEX_DIR . '/' . $indexName . '/' . $uuid;
+            $indexName = $internal ? Storage::IDX_INTERNAL_UUID : Storage::IDX_JCR_UUID;
+            $path = Storage::INDEX_DIR . '/' . $indexName . '/' . $uuid;
 
             if (!$this->filesystem->exists($path)) {
                 throw new \InvalidArgumentException(sprintf(
@@ -92,11 +92,11 @@ class NodeReader
 
     public function readBinaryStream($workspace, $path)
     {
-        $propertyValues = (array) $this->getPropertyValue($workspace, $path, 'Binary');
+        $propertyValues = $this->getPropertyValue($workspace, $path, 'Binary');
         $nodePath = $this->helper->getNodePath($workspace, dirname($path));
         $streams = array();
 
-        foreach ($propertyValues as $propertyValue) {
+        foreach ((array) $propertyValues as $propertyValue) {
             $binaryPath = sprintf('%s/%s.bin', dirname($nodePath), $propertyValue);
 
             if (!$this->filesystem->exists($binaryPath)) {
@@ -109,7 +109,7 @@ class NodeReader
             $streams[] = $this->filesystem->stream($binaryPath);
         }
 
-        if (count($streams) > 1) {
+        if (is_array($propertyValues)) {
             return $streams;
         }
 
@@ -127,9 +127,9 @@ class NodeReader
 
         $uuid = $node->{'jcr:uuid'};
 
-        $indexName = $weak === true ? self::IDX_WEAKREFERRERS_DIR : self::IDX_REFERRERS_DIR;
+        $indexName = $weak === true ? Storage::IDX_WEAKREFERRERS_DIR : Storage::IDX_REFERRERS_DIR;
 
-        $path = self::INDEX_DIR . '/' . $indexName . '/' . $uuid;
+        $path = Storage::INDEX_DIR . '/' . $indexName . '/' . $uuid;
 
         if (!$this->filesystem->exists($path)) {
             return array();

--- a/src/Transport/Fs/Filesystem/Storage/NodeWriter.php
+++ b/src/Transport/Fs/Filesystem/Storage/NodeWriter.php
@@ -52,8 +52,8 @@ class NodeWriter
         $absPath = $this->helper->getNodePath($workspace, $path);
         $this->filesystem->write($absPath, $serialized);
 
-        foreach ($this->serializer->getSerializedBinaries() as $propertyName => $binaryData) {
-            $binaryPath = sprintf('%s/%s.bin', dirname($absPath), $binaryId);
+        foreach ($this->serializer->getSerializedBinaries() as $binaryHash => $binaryData) {
+            $binaryPath = sprintf('%s/%s.bin', dirname($absPath), $binaryHash);
             $this->filesystem->write($binaryPath, base64_decode($binaryData));
         }
 

--- a/src/Transport/Fs/NodeSerializer/YamlNodeSerializer.php
+++ b/src/Transport/Fs/NodeSerializer/YamlNodeSerializer.php
@@ -58,8 +58,22 @@ class YamlNodeSerializer implements NodeSerializerInterface
             }
 
             if ($propertyTypeValue == 'Binary') {
-                $this->binaries[$propertyName] = $propertyValue;
-                $propertyValue = null;
+                $binaries = array();
+                foreach ((array) $propertyValue as $binaryData) {
+                    $binaryHash = md5($binaryData);
+                    $binaries[$binaryHash] = $binaryData;
+                    $this->binaries[$binaryHash] = $binaryData;
+                }
+
+                $binaryHashes = array_keys($binaries);
+                if (is_array($propertyValue)) {
+                    $propertyValue = array();
+                    foreach ($binaryHashes as $binaryHash) {
+                        $propertyValue[] = $binaryHash;
+                    }
+                } else {
+                    $propertyValue = reset($binaryHashes);
+                }
             }
 
             $properties[$propertyName]['type'] = $propertyTypeValue;


### PR DESCRIPTION
Binaries are stored on the filesystem and referenced as an MD5 hash of the file in the serialized node data, e.g.

```
$ cat tests/data/workspaces/tests/tests_general_base/index.txt/jcr:content/node.yml
'jcr:primaryType':
    type: Name
    value: 'nt:unstructured'
'jcr:data':
    type: Binary
    value: e7e54912265cc5b12b1d9b632254997c
multidata:
    type: Binary
    value: [e7e54912265cc5b12b1d9b632254997c]
'jcr:lastModified':
    type: Date
    value: '2009-04-27T13:01:07.472+02:00'
```

The actual binary data is stored at the nodes path

```
$ ls tests/data/workspaces/tests/tests_general_base/index.txt jcr:content
e7e54912265cc5b12b1d9b632254997c.bin  node.yml
```
